### PR TITLE
Add namespace and fix IE9 location.origin bug

### DIFF
--- a/findUrlRoot.js
+++ b/findUrlRoot.js
@@ -3,6 +3,11 @@ module.exports = function() {
 
   var roots = {};
 
+  // ie9
+  if (!window.location.origin) {
+    window.location.origin = window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port: '');
+  }
+
   var origin = location.origin;
 
   Array.prototype.slice.call(scripts).map(function (scriptTag) {

--- a/index.js
+++ b/index.js
@@ -26,7 +26,9 @@ function createFramework(emitter, io) {
     });
   });
 
-  io.on('connection', function (socket) {
+  var serverSideIo = io.of('/karma-server-side');
+
+  serverSideIo.on('connection', function (socket) {
     socket.on('server-side', function (request) {
       debug('run', request);
       run(request, function (error, result) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-server-side",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/reqres.js
+++ b/reqres.js
@@ -9,13 +9,13 @@ function messageId() {
   return Date.now() + ':' + messageIndex++;
 }
 
-var socket = io(location.host, {
+var socket = io('/karma-server-side', {
   reconnectionDelay: 500,
   reconnectionDelayMax: Infinity,
   timeout: 2000,
   path: findUrlRoot() + '/socket.io',
   'sync disconnect on unload': true,
-  transports: ['websocket', 'polling']
+  transports: ['polling', 'websocket']
 });
 
 socket.on('server-side', function (msg) {


### PR DESCRIPTION
- Polling has to go first to work (manually tested on IE9)
- `window.origin` is not available in IE9 which makes communication impossible (https://github.com/featurist/karma-server-side/issues/6)
- Use `/karma-server-side` namespace
