### PR TITLE
Fix issue in findUrlRoot.js where path is returned as undefined.

### DIFF
--- a/findUrlRoot.js
+++ b/findUrlRoot.js
@@ -29,5 +29,5 @@ module.exports = function() {
     }
   });
 
-  return mostCommonRootName;
+  return mostCommonRootName || '';
 };


### PR DESCRIPTION
This PR fixes an issues I encountered while using this package in [findUrlRoot.js](https://github.com/featurist/karma-server-side/blob/f6884377549467dbacbf52809435e8544aa23df1/findUrlRoot.js), the path was returned as undefined. The returned path is used later in [reqres,js](https://github.com/featurist/karma-server-side/blob/f6884377549467dbacbf52809435e8544aa23df1/reqres.js) and is concatenated to the string `'/socket.io'`, and the result of the string concatenation becomes `'undefined/socket.io'` and the URL for requests becomes http://localhost:12345undefined/socket.io where 12345 is the port. And this causes request to fail.

The PR change the behavior to return empty string instead of undefined in this case. I tested that change and it fixed the bug I was encountering.

Finally, I would like to thank you for creating this useful plugin and making it available. 