### PR TITLE
karma v6 update

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -2,6 +2,9 @@ var parseFunction = require('parse-function');
 var extend = require('lowscore/extend');
 var server = require('./reqres');
 
+// parse-function is now ES6, it may export "default"
+parseFunction = (parseFunction.default || parseFunction)().parse;
+
 function namedArguments(names, values) {
   var args = {};
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ var cwd = process.cwd();
 var serverRequire = require('./serverRequire');
 var parseFunction = require('parse-function');
 
+// parse-function is now ES6, it may export "default"
+parseFunction = (parseFunction.default || parseFunction)().parse;
+
 function isLocalModule(filename) {
   return filename.indexOf(cwd) != -1 && !filename.match(/[/\\]node_modules[/\\]/);
 }

--- a/package.json
+++ b/package.json
@@ -10,25 +10,25 @@
   "license": "ISC",
   "browser": "browser.js",
   "devDependencies": {
-    "browserify": "16.2.3",
-    "chai": "4.2.0",
+    "browserify": "17.0.0",
+    "chai": "4.3.6",
     "faux-jax": "5.0.6",
     "fs-promise": "2.0.3",
-    "karma": "4.1.0",
-    "karma-browserify": "6.0.0",
-    "karma-browserstack-launcher": "1.5.1",
-    "karma-chrome-launcher": "2.2.0",
+    "karma": "6.3.15",
+    "karma-browserify": "8.1.0",
+    "karma-browserstack-launcher": "1.6.0",
+    "karma-chrome-launcher": "3.1.0",
     "karma-ievms": "0.1.0",
-    "karma-mocha": "1.3.0",
+    "karma-mocha": "2.0.1",
     "karma-mocha-reporter": "2.2.5",
     "lie": "3.3.0",
-    "mocha": "^6.1.4",
-    "watchify": "3.11.1"
+    "mocha": "^9.2.0",
+    "watchify": "4.0.0"
   },
   "dependencies": {
     "lowscore": "1.17.0",
-    "parse-function": "^2.3.2",
-    "socket.io-client": "2.2.0"
+    "parse-function": "^5.6.10",
+    "socket.io-client": "4.4.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hello,

Here are some updates to make karma-server-side compatible with Karma >= v6, main issue was socket.io being unable to connect to to some protocol version changes.

- updated all dependencies using npm-check-updates
- fixed parse-function according to API changes

Tests are passing (on Chromium):
![image](https://user-images.githubusercontent.com/417230/152799485-e0f11590-da33-441c-9ba6-318323179aae.png)

PS: I've been using this project for quite a while and couldn't find any replacement, if this project is un-maintained could you hint on any replacements ?

Thank you for this awesome project !
